### PR TITLE
feat: add provider presets and reasoning controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You have to use your own LLM provider and keys :)
 - Custom prompt command for one-off prompts without creating a file
 - Configurable reasoning effort for supported models
 - Provider capability checks that flag unsupported reasoning levels
+- Provider model autocomplete with support for custom model names
 - Local-first behavior: your prompt files stay in your vault
 
 ## 2-minute quick start

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You have to use your own LLM provider and keys :)
 - Streaming output directly into the editor selection/cursor
 - Custom prompt command for one-off prompts without creating a file
 - Configurable reasoning effort for supported models
+- Provider capability checks that flag unsupported reasoning levels
 - Local-first behavior: your prompt files stay in your vault
 
 ## 2-minute quick start
@@ -43,7 +44,7 @@ You have to use your own LLM provider and keys :)
    - `🔑 API key`
    - `🌐 Base URL` (example: `https://api.openai.com/v1`)
    - `🤖 Model name` (example: `gpt-4.1-mini`)
-   - `🧠 Reasoning effort` (optional; for supported reasoning models)
+   - `🧠 Reasoning effort` (optional; available levels are checked against the selected model)
 3. Create a prompt folder (default: `_prompts`).
 4. Add a prompt file, for example `_prompts/Writing/Improve.md`:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ You have to use your own LLM provider and keys :)
 - Prompt files become commands automatically (including nested folders)
 - Streaming output directly into the editor selection/cursor
 - Custom prompt command for one-off prompts without creating a file
+- Configurable reasoning effort for supported models
 - Local-first behavior: your prompt files stay in your vault
 
 ## 2-minute quick start
@@ -42,6 +43,7 @@ You have to use your own LLM provider and keys :)
    - `🔑 API key`
    - `🌐 Base URL` (example: `https://api.openai.com/v1`)
    - `🤖 Model name` (example: `gpt-4.1-mini`)
+   - `🧠 Reasoning effort` (optional; for supported reasoning models)
 3. Create a prompt folder (default: `_prompts`).
 4. Add a prompt file, for example `_prompts/Writing/Improve.md`:
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You have to use your own LLM provider and keys :)
 - Configurable reasoning effort for supported models
 - Provider capability checks that flag unsupported reasoning levels
 - Provider model autocomplete with support for custom model names
+- Multiple provider/model presets with a response test for the current preset
 - Local-first behavior: your prompt files stay in your vault
 
 ## 2-minute quick start

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1",
-        "openai": "^6.8.1"
+        "openai": "^7.5.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -1158,7 +1158,8 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1224,7 +1225,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1809,7 +1809,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1884,7 +1883,6 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -2214,7 +2212,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2687,7 +2684,8 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3085,7 +3083,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5375,18 +5372,30 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.8.1.tgz",
-      "integrity": "sha512-ACifslrVgf+maMz9vqwMP4+v9qvx5Yzssydizks8n+YUJ6YwUoxj51sKRQ8HYMfR6wgKLSIlaI108ZwCk+8yig==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-7.5.0.tgz",
+      "integrity": "sha512-ZbDBz8FSB8Mv8fFYIUvzTFMdV5vl93/octp1MdtK2lfYepSpfv/ewmeugpKz/cwGtFSx+YuUM4NwpZ2P55YiPA==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
+      "engines": {
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
         "ws": {
           "optional": true
         },
@@ -5850,7 +5859,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodeutils/defaults-deep": "1.1.0",
         "@octokit/rest": "22.0.1",
@@ -6253,7 +6261,8 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -6323,7 +6332,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6393,7 +6401,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6535,7 +6542,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -7113,7 +7119,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7217,7 +7222,8 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "openai": "^6.8.1"
+    "openai": "^7.5.0"
   }
 }

--- a/src/llm/get-model-reasoning-support.spec.ts
+++ b/src/llm/get-model-reasoning-support.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   getModelReasoningSupport,
   parseModelReasoningSupport,
+  parseProviderModels,
 } from "./get-model-reasoning-support";
 
 describe("getModelReasoningSupport", () => {
@@ -39,6 +40,34 @@ describe("getModelReasoningSupport", () => {
     expect(headers instanceof Headers ? headers.get("Authorization") : null).toBe(
       "Bearer secret",
     );
+  });
+});
+
+describe("parseProviderModels", () => {
+  it("returns model records with valid IDs for autocomplete", () => {
+    expect(
+      parseProviderModels({
+        data: [
+          { id: "provider/model-a", name: "Model A" },
+          { id: "provider/model-b" },
+          { name: "Missing ID" },
+          null,
+        ],
+      }),
+    ).toEqual({
+      status: "success",
+      models: [
+        { id: "provider/model-a", name: "Model A" },
+        { id: "provider/model-b" },
+      ],
+    });
+  });
+
+  it("rejects responses without a model data array", () => {
+    expect(parseProviderModels({ models: [] })).toEqual({
+      status: "unknown",
+      reason: "not-advertised",
+    });
   });
 });
 

--- a/src/llm/get-model-reasoning-support.spec.ts
+++ b/src/llm/get-model-reasoning-support.spec.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getModelReasoningSupport,
+  parseModelReasoningSupport,
+} from "./get-model-reasoning-support";
+
+describe("getModelReasoningSupport", () => {
+  it("requests the provider models endpoint with authentication", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: "provider/model",
+              reasoning: { supported_efforts: ["high"] },
+            },
+          ],
+        }),
+      ),
+    );
+
+    await expect(
+      getModelReasoningSupport({
+        baseUrl: "https://provider.example/v1/",
+        apiKey: "secret",
+        model: "provider/model",
+        fetch,
+      }),
+    ).resolves.toEqual({ status: "supported", efforts: ["high"] });
+
+    expect(fetch).toHaveBeenCalledWith(
+      new URL("https://provider.example/v1/models"),
+      expect.objectContaining({
+        headers: expect.any(Headers),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    const headers = fetch.mock.calls[0]?.[1]?.headers;
+    expect(headers instanceof Headers ? headers.get("Authorization") : null).toBe(
+      "Bearer secret",
+    );
+  });
+});
+
+describe("parseModelReasoningSupport", () => {
+  it("parses all efforts advertised for GPT-5.6 Sol", () => {
+    expect(
+      parseModelReasoningSupport(
+        {
+          data: [
+            {
+              id: "openai/gpt-5.6-sol",
+              reasoning: {
+                mandatory: false,
+                default_enabled: true,
+                supported_efforts: [
+                  "max",
+                  "xhigh",
+                  "high",
+                  "medium",
+                  "low",
+                  "none",
+                ],
+                default_effort: "medium",
+              },
+            },
+          ],
+        },
+        "openai/gpt-5.6-sol",
+      ),
+    ).toEqual({
+      status: "supported",
+      efforts: ["max", "xhigh", "high", "medium", "low", "none"],
+    });
+  });
+
+  it("returns the reasoning efforts advertised for a model", () => {
+    expect(
+      parseModelReasoningSupport(
+        {
+          data: [
+            {
+              id: "provider/model",
+              reasoning: {
+                supported_efforts: [
+                  "max",
+                  "xhigh",
+                  "high",
+                  "low",
+                  "none",
+                  "unsupported-value",
+                ],
+              },
+            },
+          ],
+        },
+        "provider/model",
+      ),
+    ).toEqual({
+      status: "supported",
+      efforts: ["max", "xhigh", "high", "low", "none"],
+    });
+  });
+
+  it("supports all efforts when the provider returns null", () => {
+    expect(
+      parseModelReasoningSupport(
+        {
+          data: [
+            {
+              id: "provider/model",
+              reasoning: { supported_efforts: null },
+            },
+          ],
+        },
+        "provider/model",
+      ),
+    ).toEqual({
+      status: "supported",
+      efforts: ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+    });
+  });
+
+  it("does not guess levels from a reasoning parameter", () => {
+    expect(
+      parseModelReasoningSupport(
+        {
+          data: [
+            {
+              id: "provider/model",
+              supported_parameters: ["temperature", "reasoning"],
+            },
+          ],
+        },
+        "provider/model",
+      ),
+    ).toEqual({ status: "unknown", reason: "not-advertised" });
+  });
+
+  it("returns unsupported when provider metadata excludes reasoning", () => {
+    expect(
+      parseModelReasoningSupport(
+        {
+          data: [
+            { id: "provider/model", supported_parameters: ["temperature"] },
+          ],
+        },
+        "provider/model",
+      ),
+    ).toEqual({ status: "unsupported" });
+  });
+
+  it("does not guess when a provider does not advertise capabilities", () => {
+    expect(
+      parseModelReasoningSupport(
+        { data: [{ id: "provider/model", object: "model" }] },
+        "provider/model",
+      ),
+    ).toEqual({ status: "unknown", reason: "not-advertised" });
+  });
+
+  it("does not treat unknown future efforts as unsupported", () => {
+    expect(
+      parseModelReasoningSupport(
+        {
+          data: [
+            {
+              id: "provider/model",
+              reasoning: { supported_efforts: ["future-level"] },
+            },
+          ],
+        },
+        "provider/model",
+      ),
+    ).toEqual({ status: "unknown", reason: "not-advertised" });
+  });
+});

--- a/src/llm/get-model-reasoning-support.spec.ts
+++ b/src/llm/get-model-reasoning-support.spec.ts
@@ -150,6 +150,44 @@ describe("parseModelReasoningSupport", () => {
     });
   });
 
+  it("excludes none when null efforts are mandatory", () => {
+    expect(
+      parseModelReasoningSupport(
+        {
+          data: [
+            {
+              id: "provider/model",
+              reasoning: { mandatory: true, supported_efforts: null },
+            },
+          ],
+        },
+        "provider/model",
+      ),
+    ).toEqual({
+      status: "supported",
+      efforts: ["minimal", "low", "medium", "high", "xhigh", "max"],
+    });
+  });
+
+  it("excludes explicit none when reasoning is mandatory", () => {
+    expect(
+      parseModelReasoningSupport(
+        {
+          data: [
+            {
+              id: "provider/model",
+              reasoning: {
+                mandatory: true,
+                supported_efforts: ["high", "none"],
+              },
+            },
+          ],
+        },
+        "provider/model",
+      ),
+    ).toEqual({ status: "supported", efforts: ["high"] });
+  });
+
   it("does not guess levels from a reasoning parameter", () => {
     expect(
       parseModelReasoningSupport(

--- a/src/llm/get-model-reasoning-support.ts
+++ b/src/llm/get-model-reasoning-support.ts
@@ -15,10 +15,18 @@ export type ModelReasoningSupport =
       readonly reason: "invalid-config" | "lookup-failed" | "not-advertised";
     };
 
-type GetModelReasoningSupportParams = {
+export type ProviderModel = Record<string, unknown> & { readonly id: string };
+
+export type ProviderModelsResult =
+  | { readonly status: "success"; readonly models: readonly ProviderModel[] }
+  | {
+      readonly status: "unknown";
+      readonly reason: "invalid-config" | "lookup-failed" | "not-advertised";
+    };
+
+type GetProviderModelsParams = {
   readonly baseUrl: string;
   readonly apiKey: string;
-  readonly model: string;
   readonly fetch: typeof globalThis.fetch;
 };
 
@@ -27,8 +35,23 @@ export async function getModelReasoningSupport({
   apiKey,
   model,
   fetch,
-}: GetModelReasoningSupportParams): Promise<ModelReasoningSupport> {
-  if (!baseUrl || !model) {
+}: GetProviderModelsParams & { readonly model: string }): Promise<ModelReasoningSupport> {
+  if (!model) {
+    return { status: "unknown", reason: "invalid-config" };
+  }
+
+  const result = await getProviderModels({ baseUrl, apiKey, fetch });
+  return result.status === "success"
+    ? parseModelReasoningSupportFromModels(result.models, model)
+    : result;
+}
+
+export async function getProviderModels({
+  baseUrl,
+  apiKey,
+  fetch,
+}: GetProviderModelsParams): Promise<ProviderModelsResult> {
+  if (!baseUrl) {
     return { status: "unknown", reason: "invalid-config" };
   }
 
@@ -52,7 +75,7 @@ export async function getModelReasoningSupport({
       return { status: "unknown", reason: "lookup-failed" };
     }
 
-    return parseModelReasoningSupport(await response.json(), model);
+    return parseProviderModels(await response.json());
   } catch {
     return { status: "unknown", reason: "lookup-failed" };
   } finally {
@@ -64,11 +87,25 @@ export function parseModelReasoningSupport(
   response: unknown,
   modelId: string,
 ): ModelReasoningSupport {
+  const result = parseProviderModels(response);
+  return result.status === "success"
+    ? parseModelReasoningSupportFromModels(result.models, modelId)
+    : { status: "unknown", reason: "not-advertised" };
+}
+
+export function parseProviderModels(response: unknown): ProviderModelsResult {
   if (!isRecord(response) || !Array.isArray(response.data)) {
     return { status: "unknown", reason: "not-advertised" };
   }
 
-  const models = response.data.filter(isRecord);
+  const models = response.data.filter(isProviderModel);
+  return { status: "success", models };
+}
+
+export function parseModelReasoningSupportFromModels(
+  models: readonly ProviderModel[],
+  modelId: string,
+): ModelReasoningSupport {
   const model = models.find((candidate) => candidate.id === modelId);
   if (!model) {
     return { status: "unknown", reason: "not-advertised" };
@@ -106,4 +143,8 @@ export function parseModelReasoningSupport(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function isProviderModel(value: unknown): value is ProviderModel {
+  return isRecord(value) && typeof value.id === "string";
 }

--- a/src/llm/get-model-reasoning-support.ts
+++ b/src/llm/get-model-reasoning-support.ts
@@ -112,13 +112,22 @@ export function parseModelReasoningSupportFromModels(
   }
 
   if (isRecord(model.reasoning)) {
+    const isMandatory = model.reasoning.mandatory === true;
     const supportedEfforts = model.reasoning.supported_efforts;
     if (supportedEfforts === null) {
-      return { status: "supported", efforts: REASONING_EFFORTS };
+      return {
+        status: "supported",
+        efforts: isMandatory
+          ? REASONING_EFFORTS.filter((effort) => effort !== "none")
+          : REASONING_EFFORTS,
+      };
     }
     if (Array.isArray(supportedEfforts)) {
-      const efforts = supportedEfforts.filter(isReasoningEffort);
-      if (efforts.length > 0) {
+      const recognizedEfforts = supportedEfforts.filter(isReasoningEffort);
+      const efforts = isMandatory
+        ? recognizedEfforts.filter((effort) => effort !== "none")
+        : recognizedEfforts;
+      if (recognizedEfforts.length > 0) {
         return { status: "supported", efforts };
       }
       return supportedEfforts.length === 0

--- a/src/llm/get-model-reasoning-support.ts
+++ b/src/llm/get-model-reasoning-support.ts
@@ -1,0 +1,109 @@
+import {
+  isReasoningEffort,
+  REASONING_EFFORTS,
+  type ReasoningEffort,
+} from "./reasoning-effort";
+
+export type ModelReasoningSupport =
+  | {
+      readonly status: "supported";
+      readonly efforts: readonly ReasoningEffort[];
+    }
+  | { readonly status: "unsupported" }
+  | {
+      readonly status: "unknown";
+      readonly reason: "invalid-config" | "lookup-failed" | "not-advertised";
+    };
+
+type GetModelReasoningSupportParams = {
+  readonly baseUrl: string;
+  readonly apiKey: string;
+  readonly model: string;
+  readonly fetch: typeof globalThis.fetch;
+};
+
+export async function getModelReasoningSupport({
+  baseUrl,
+  apiKey,
+  model,
+  fetch,
+}: GetModelReasoningSupportParams): Promise<ModelReasoningSupport> {
+  if (!baseUrl || !model) {
+    return { status: "unknown", reason: "invalid-config" };
+  }
+
+  let modelsUrl: URL;
+  try {
+    modelsUrl = new URL(`${baseUrl.replace(/\/$/, "")}/models`);
+  } catch {
+    return { status: "unknown", reason: "invalid-config" };
+  }
+
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), 10_000);
+  try {
+    const response = await fetch(modelsUrl, {
+      ...(apiKey
+        ? { headers: new Headers({ Authorization: `Bearer ${apiKey}` }) }
+        : {}),
+      signal: abortController.signal,
+    });
+    if (!response.ok) {
+      return { status: "unknown", reason: "lookup-failed" };
+    }
+
+    return parseModelReasoningSupport(await response.json(), model);
+  } catch {
+    return { status: "unknown", reason: "lookup-failed" };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function parseModelReasoningSupport(
+  response: unknown,
+  modelId: string,
+): ModelReasoningSupport {
+  if (!isRecord(response) || !Array.isArray(response.data)) {
+    return { status: "unknown", reason: "not-advertised" };
+  }
+
+  const models = response.data.filter(isRecord);
+  const model = models.find((candidate) => candidate.id === modelId);
+  if (!model) {
+    return { status: "unknown", reason: "not-advertised" };
+  }
+
+  if (isRecord(model.reasoning)) {
+    const supportedEfforts = model.reasoning.supported_efforts;
+    if (supportedEfforts === null) {
+      return { status: "supported", efforts: REASONING_EFFORTS };
+    }
+    if (Array.isArray(supportedEfforts)) {
+      const efforts = supportedEfforts.filter(isReasoningEffort);
+      if (efforts.length > 0) {
+        return { status: "supported", efforts };
+      }
+      return supportedEfforts.length === 0
+        ? { status: "unsupported" }
+        : { status: "unknown", reason: "not-advertised" };
+    }
+    return { status: "unknown", reason: "not-advertised" };
+  }
+
+  if (Array.isArray(model.supported_parameters)) {
+    if (!model.supported_parameters.every((value) => typeof value === "string")) {
+      return { status: "unknown", reason: "not-advertised" };
+    }
+    return model.supported_parameters.includes("reasoning_effort") ||
+      model.supported_parameters.includes("reasoning")
+      ? { status: "unknown", reason: "not-advertised" }
+      : { status: "unsupported" };
+  }
+
+  return { status: "unknown", reason: "not-advertised" };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/llm/llm-client.spec.ts
+++ b/src/llm/llm-client.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_PROMPT_OPTIONS } from "../prompt/user-prompt-options";
+import { UserContentSelection } from "../prompt/user-content-selection/user-content-selection";
+import { LLMClient } from "./llm-client";
+
+const { createChatCompletion } = vi.hoisted(() => ({
+  createChatCompletion: vi.fn(),
+}));
+
+vi.mock("openai", () => ({
+  APIUserAbortError: class extends Error {},
+  OpenAI: class {
+    chat = {
+      completions: {
+        create: createChatCompletion,
+      },
+    };
+  },
+}));
+
+const userContentSelection = new UserContentSelection("Content", {
+  anchor: { line: 0, ch: 0 },
+  head: { line: 0, ch: 0 },
+});
+
+async function requestResponse(client: LLMClient) {
+  const response = client.getResponse({
+    userPromptString: "Prompt",
+    userContentSelection,
+    userPromptOptions: DEFAULT_PROMPT_OPTIONS,
+  });
+
+  await response.next();
+}
+
+describe("LLMClient reasoning effort", () => {
+  beforeEach(() => {
+    createChatCompletion.mockReset();
+    createChatCompletion.mockResolvedValue(
+      (async function* () {
+        yield { choices: [{ delta: { content: "Response" } }] };
+      })(),
+    );
+  });
+
+  it("sends the selected reasoning effort", async () => {
+    const client = new LLMClient({ apiKey: "key" }, "model", "high");
+
+    await requestResponse(client);
+
+    expect(createChatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ reasoning_effort: "high" }),
+      { signal: undefined },
+    );
+  });
+
+  it("omits reasoning effort when using the provider default", async () => {
+    const client = new LLMClient({ apiKey: "key" }, "model");
+
+    await requestResponse(client);
+
+    const request = createChatCompletion.mock.calls[0]?.[0];
+    expect(request).not.toHaveProperty("reasoning_effort");
+  });
+});

--- a/src/llm/llm-client.spec.ts
+++ b/src/llm/llm-client.spec.ts
@@ -44,12 +44,12 @@ describe("LLMClient reasoning effort", () => {
   });
 
   it("sends the selected reasoning effort", async () => {
-    const client = new LLMClient({ apiKey: "key" }, "model", "high");
+    const client = new LLMClient({ apiKey: "key" }, "model", "xhigh");
 
     await requestResponse(client);
 
     expect(createChatCompletion).toHaveBeenCalledWith(
-      expect.objectContaining({ reasoning_effort: "high" }),
+      expect.objectContaining({ reasoning_effort: "xhigh" }),
       { signal: undefined },
     );
   });

--- a/src/llm/llm-client.spec.ts
+++ b/src/llm/llm-client.spec.ts
@@ -62,4 +62,21 @@ describe("LLMClient reasoning effort", () => {
     const request = createChatCompletion.mock.calls[0]?.[0];
     expect(request).not.toHaveProperty("reasoning_effort");
   });
+
+  it("tests the configured model and reasoning effort", async () => {
+    const client = new LLMClient({ apiKey: "key" }, "model", "max");
+    const abortController = new AbortController();
+
+    await client.testConnection(abortController.signal);
+
+    expect(createChatCompletion).toHaveBeenCalledWith(
+      {
+        model: "model",
+        messages: [{ role: "user", content: "Reply only with OK." }],
+        stream: true,
+        reasoning_effort: "max",
+      },
+      { signal: abortController.signal },
+    );
+  });
 });

--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -9,6 +9,7 @@ import { UserContentSelection } from "../prompt/user-content-selection/user-cont
 import type { PromptOptions } from "../prompt/user-prompt-options";
 import { AbortError } from "../utils/abort-error";
 import { createOpenAiRequestMessages } from "./create-open-ai-request-messages";
+import type { ReasoningEffort } from "./reasoning-effort";
 
 type GetResponseParams = {
   readonly userPromptString: string;
@@ -23,6 +24,7 @@ export class LLMClient {
   constructor(
     options: Pick<OpenAIOptions, "apiKey" | "baseURL" | "fetch" | "project">,
     private readonly model: string,
+    private readonly reasoningEffort?: ReasoningEffort,
   ) {
     this.client = new OpenAI({
       ...options,
@@ -58,6 +60,9 @@ export class LLMClient {
           model: this.model,
           messages,
           stream: true,
+          ...(this.reasoningEffort
+            ? { reasoning_effort: this.reasoningEffort }
+            : {}),
         },
         {
           signal,

--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -33,6 +33,31 @@ export class LLMClient {
     });
   }
 
+  async testConnection(signal?: AbortSignal): Promise<void> {
+    try {
+      const response = await this.client.chat.completions.create(
+        {
+          model: this.model,
+          messages: [{ role: "user", content: "Reply only with OK." }],
+          stream: true,
+          ...(this.reasoningEffort
+            ? { reasoning_effort: this.reasoningEffort }
+            : {}),
+        },
+        { signal },
+      );
+      for await (const _chunk of response) {
+        return;
+      }
+      throw new Error("Model returned an empty response stream");
+    } catch (error: unknown) {
+      if (error instanceof APIUserAbortError) {
+        throw new AbortError();
+      }
+      throw error;
+    }
+  }
+
   async *getResponse({
     userContentSelection,
     userPromptString,

--- a/src/llm/reasoning-effort.spec.ts
+++ b/src/llm/reasoning-effort.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { isReasoningEffort } from "./reasoning-effort";
 
 describe("isReasoningEffort", () => {
-  it.each(["minimal", "low", "medium", "high"])(
+  it.each(["none", "minimal", "low", "medium", "high", "xhigh", "max"])(
     "accepts %s",
     (reasoningEffort) => {
       expect(isReasoningEffort(reasoningEffort)).toBe(true);

--- a/src/llm/reasoning-effort.spec.ts
+++ b/src/llm/reasoning-effort.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isReasoningEffort } from "./reasoning-effort";
+
+describe("isReasoningEffort", () => {
+  it.each(["minimal", "low", "medium", "high"])(
+    "accepts %s",
+    (reasoningEffort) => {
+      expect(isReasoningEffort(reasoningEffort)).toBe(true);
+    },
+  );
+
+  it.each([undefined, "", "default", "extreme", 1])(
+    "rejects %s",
+    (reasoningEffort) => {
+      expect(isReasoningEffort(reasoningEffort)).toBe(false);
+    },
+  );
+});

--- a/src/llm/reasoning-effort.ts
+++ b/src/llm/reasoning-effort.ts
@@ -1,0 +1,12 @@
+export const REASONING_EFFORTS = [
+  "minimal",
+  "low",
+  "medium",
+  "high",
+] as const;
+
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
+
+export function isReasoningEffort(value: unknown): value is ReasoningEffort {
+  return REASONING_EFFORTS.some((effort) => effort === value);
+}

--- a/src/llm/reasoning-effort.ts
+++ b/src/llm/reasoning-effort.ts
@@ -1,8 +1,11 @@
 export const REASONING_EFFORTS = [
+  "none",
   "minimal",
   "low",
   "medium",
   "high",
+  "xhigh",
+  "max",
 ] as const;
 
 export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,17 +12,19 @@ import {
 } from "obsidian";
 import { mapLlmErrorToReadable } from "./llm/error-handler";
 import { LLMClient } from "./llm/llm-client";
-import {
-  isReasoningEffort,
-  type ReasoningEffort,
-} from "./llm/reasoning-effort";
 import { logger } from "./logger";
 import { parsePromptOptionsFromFileProperties } from "./prompt/parse-prompt-options-from-file-properties/parse-prompt-options-from-file-properties";
 import { mergePromptOptions } from "./prompt/prompt-option-registry";
 import { UserContentSelection } from "./prompt/user-content-selection/user-content-selection";
-import type { PromptOptions } from "./prompt/user-prompt-options";
-import { DEFAULT_PROMPT_OPTIONS } from "./prompt/user-prompt-options";
 import { UserPromptParams } from "./prompt/user-prompt-params";
+import {
+  clonePluginSettings,
+  createDefaultSettings,
+  getCurrentPreset,
+  migratePluginSettings,
+  type PluginSettings,
+  type ProviderPreset,
+} from "./settings";
 import { SettingTab } from "./setting-tab";
 import { InfoModal } from "./ui/info-modal/info-modal";
 import { LoaderStrategy, LoaderStrategyFactory } from "./ui/loader-strategy";
@@ -33,42 +35,33 @@ import { assertExists } from "./utils/assertions/assert-exists";
 import { PLUGIN_NAME } from "./utils/constants";
 import { obsidianFetchAdapter } from "./utils/obsidian/obsidian-fetch-adapter";
 
-interface PluginSettings {
-  apiKey: string;
-  providerUrl: string;
-  model: string;
-  reasoningEffort: ReasoningEffort | undefined;
-  promptLibraryDirectory: string;
-  project: string;
-  customPromptCommandLabel: string;
-  globalPromptOptions: PromptOptions;
-}
-
-const DEFAULT_SETTINGS: PluginSettings = {
-  apiKey: "",
-  providerUrl: "",
-  model: "",
-  reasoningEffort: undefined,
-  promptLibraryDirectory: "_prompts",
-  project: "",
-  customPromptCommandLabel: "Custom prompt",
-  globalPromptOptions: DEFAULT_PROMPT_OPTIONS,
-};
-
 export default class LlmShortcutPlugin extends Plugin {
-  public settings: PluginSettings = DEFAULT_SETTINGS;
+  public settings: PluginSettings = createDefaultSettings();
   private llmClient?: LLMClient;
   private readonly loaderStrategy: LoaderStrategy;
   private commands: Command[] = [];
   private eventRefs: EventRef[] = [];
   private abortController: AbortController | undefined;
+  private pendingSettingsSnapshot: PluginSettings | undefined;
+  private settingsSavePromise: Promise<void> | undefined;
+  private isUnloaded = false;
 
   constructor(app: App, manifest: PluginManifest) {
     super(app, manifest);
     this.loaderStrategy = LoaderStrategyFactory.createStrategy(this);
   }
 
+  public get currentPreset(): ProviderPreset {
+    return getCurrentPreset(this.settings);
+  }
+
+  public async testCurrentPreset(signal?: AbortSignal): Promise<void> {
+    const preset = { ...this.currentPreset };
+    await this.createLlmClient(preset).testConnection(signal);
+  }
+
   override async onload() {
+    this.isUnloaded = false;
     logger.debug("Loading plugin");
     await this.loadSettings();
     this.initSettingsTab();
@@ -407,19 +400,25 @@ export default class LlmShortcutPlugin extends Plugin {
   }
 
   private loadAiClient() {
-    this.llmClient = new LLMClient(
+    this.llmClient = this.createLlmClient(this.currentPreset);
+  }
+
+  private createLlmClient(preset: ProviderPreset): LLMClient {
+    return new LLMClient(
       {
-        apiKey: this.settings.apiKey,
-        baseURL: this.settings.providerUrl,
+        apiKey: preset.apiKey,
+        baseURL: preset.providerUrl,
         fetch: obsidianFetchAdapter,
-        project: this.settings.project,
+        project: preset.project,
       },
-      this.settings.model,
-      this.settings.reasoningEffort,
+      preset.model,
+      preset.reasoningEffort,
     );
   }
 
   override onunload() {
+    this.isUnloaded = true;
+    this.pendingSettingsSnapshot = undefined;
     this.abortController?.abort();
     this.loaderStrategy.stop();
     this.eventRefs.forEach((eventRef) => this.app.vault.offref(eventRef));
@@ -427,26 +426,37 @@ export default class LlmShortcutPlugin extends Plugin {
   }
 
   async loadSettings() {
-    const data = await this.loadData();
-    this.settings = {
-      ...DEFAULT_SETTINGS,
-      ...data,
-      reasoningEffort: isReasoningEffort(data?.reasoningEffort)
-        ? data.reasoningEffort
-        : undefined,
-      globalPromptOptions: {
-        ...DEFAULT_SETTINGS.globalPromptOptions,
-        ...data?.globalPromptOptions,
-      },
-    };
+    this.settings = migratePluginSettings(await this.loadData());
   }
 
   async saveSettings() {
-    await this.saveData(this.settings);
-    await this.loadSettings();
-
     this.loadAiClient();
-    await this.reinitializeCommands();
+    this.pendingSettingsSnapshot = clonePluginSettings(this.settings);
+
+    do {
+      await (this.settingsSavePromise ?? this.startSettingsSave());
+    } while (this.pendingSettingsSnapshot && !this.isUnloaded);
+  }
+
+  private startSettingsSave(): Promise<void> {
+    const save = this.flushSettings();
+    this.settingsSavePromise = save;
+    const clearSave = () => {
+      if (this.settingsSavePromise === save) {
+        this.settingsSavePromise = undefined;
+      }
+    };
+    void save.then(clearSave, clearSave);
+    return save;
+  }
+
+  private async flushSettings(): Promise<void> {
+    while (this.pendingSettingsSnapshot && !this.isUnloaded) {
+      const snapshot = this.pendingSettingsSnapshot;
+      this.pendingSettingsSnapshot = undefined;
+      await this.saveData(snapshot);
+    }
+    if (!this.isUnloaded) await this.reinitializeCommands();
   }
 
   private async reinitializeCommands() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,10 @@ import {
 } from "obsidian";
 import { mapLlmErrorToReadable } from "./llm/error-handler";
 import { LLMClient } from "./llm/llm-client";
+import {
+  isReasoningEffort,
+  type ReasoningEffort,
+} from "./llm/reasoning-effort";
 import { logger } from "./logger";
 import { parsePromptOptionsFromFileProperties } from "./prompt/parse-prompt-options-from-file-properties/parse-prompt-options-from-file-properties";
 import { mergePromptOptions } from "./prompt/prompt-option-registry";
@@ -33,6 +37,7 @@ interface PluginSettings {
   apiKey: string;
   providerUrl: string;
   model: string;
+  reasoningEffort: ReasoningEffort | undefined;
   promptLibraryDirectory: string;
   project: string;
   customPromptCommandLabel: string;
@@ -43,6 +48,7 @@ const DEFAULT_SETTINGS: PluginSettings = {
   apiKey: "",
   providerUrl: "",
   model: "",
+  reasoningEffort: undefined,
   promptLibraryDirectory: "_prompts",
   project: "",
   customPromptCommandLabel: "Custom prompt",
@@ -409,6 +415,7 @@ export default class LlmShortcutPlugin extends Plugin {
         project: this.settings.project,
       },
       this.settings.model,
+      this.settings.reasoningEffort,
     );
   }
 
@@ -424,6 +431,9 @@ export default class LlmShortcutPlugin extends Plugin {
     this.settings = {
       ...DEFAULT_SETTINGS,
       ...data,
+      reasoningEffort: isReasoningEffort(data?.reasoningEffort)
+        ? data.reasoningEffort
+        : undefined,
       globalPromptOptions: {
         ...DEFAULT_SETTINGS.globalPromptOptions,
         ...data?.globalPromptOptions,

--- a/src/setting-tab.module.css
+++ b/src/setting-tab.module.css
@@ -1,0 +1,11 @@
+.statusSuccess {
+  color: var(--text-success);
+}
+
+.statusWarning {
+  color: var(--text-warning);
+}
+
+.statusMuted {
+  color: var(--text-muted);
+}

--- a/src/setting-tab.ts
+++ b/src/setting-tab.ts
@@ -5,8 +5,10 @@ import {
   Setting,
 } from "obsidian";
 import {
-  getModelReasoningSupport,
+  getProviderModels,
+  parseModelReasoningSupportFromModels,
   type ModelReasoningSupport,
+  type ProviderModelsResult,
 } from "./llm/get-model-reasoning-support";
 import {
   isReasoningEffort,
@@ -35,53 +37,92 @@ export class SettingTab extends PluginSettingTab {
       setting?: Setting;
       dropdown?: DropdownComponent;
     } = {};
-    const refreshReasoningSupport = async () => {
+    const modelDatalist = containerEl.createEl("datalist");
+    modelDatalist.id = "llm-shortcut-model-suggestions";
+    const modelControl: { setting?: Setting } = {};
+    let providerModelsResult: ProviderModelsResult | undefined;
+
+    const applyProviderModels = async (
+      result: ProviderModelsResult,
+      clearUnsupportedEffort: boolean,
+    ) => {
       const { setting, dropdown } = reasoningControl;
-      if (!setting || !dropdown) return;
+      const modelSetting = modelControl.setting;
+      if (!modelSetting || !setting || !dropdown) return;
 
-      const currentLookupId = ++this.reasoningSupportLookupId;
-      const lookupConfig = {
-        apiKey: this.plugin.settings.apiKey,
-        baseUrl: this.plugin.settings.providerUrl,
-        model: this.plugin.settings.model,
-      };
-      this.showReasoningSupport(
-        setting,
-        dropdown,
-        undefined,
-      );
-      const support = await getModelReasoningSupport({
-        ...lookupConfig,
-        fetch: obsidianFetchAdapter,
-      });
-      if (
-        currentLookupId !== this.reasoningSupportLookupId ||
-        lookupConfig.apiKey !== this.plugin.settings.apiKey ||
-        lookupConfig.baseUrl !== this.plugin.settings.providerUrl ||
-        lookupConfig.model !== this.plugin.settings.model
-      ) {
-        return;
-      }
-
+      this.showModelCatalogStatus(modelSetting, result, this.plugin.settings.model);
+      const support: ModelReasoningSupport =
+        !this.plugin.settings.model
+          ? { status: "unknown", reason: "invalid-config" }
+          : result.status === "success"
+          ? parseModelReasoningSupportFromModels(
+              result.models,
+              this.plugin.settings.model,
+            )
+          : result;
       const shouldClearEffort = this.showReasoningSupport(
         setting,
         dropdown,
         support,
       );
-      if (shouldClearEffort) {
+      if (shouldClearEffort && clearUnsupportedEffort) {
         this.plugin.settings.reasoningEffort = undefined;
         dropdown.setValue("");
         await this.plugin.saveSettings();
       }
     };
 
-    const scheduleReasoningSupportRefresh = () => {
+    const refreshProviderModels = async () => {
+      const { setting, dropdown } = reasoningControl;
+      const modelSetting = modelControl.setting;
+      if (!modelSetting || !setting || !dropdown) return;
+
+      const currentLookupId = ++this.reasoningSupportLookupId;
+      const lookupConfig = {
+        apiKey: this.plugin.settings.apiKey,
+        baseUrl: this.plugin.settings.providerUrl,
+      };
+      this.showModelCatalogStatus(modelSetting, undefined);
+      this.showReasoningSupport(
+        setting,
+        dropdown,
+        undefined,
+      );
+      const result = await getProviderModels({
+        ...lookupConfig,
+        fetch: obsidianFetchAdapter,
+      });
+      if (
+        currentLookupId !== this.reasoningSupportLookupId ||
+        lookupConfig.apiKey !== this.plugin.settings.apiKey ||
+        lookupConfig.baseUrl !== this.plugin.settings.providerUrl
+      ) {
+        return;
+      }
+
+      providerModelsResult = result;
+      this.setModelSuggestions(
+        modelDatalist,
+        result.status === "success" ? result.models.map(({ id }) => id) : [],
+      );
+      await applyProviderModels(result, true);
+    };
+
+    const scheduleProviderModelsRefresh = () => {
       this.reasoningSupportLookupId += 1;
+      providerModelsResult = undefined;
+      this.setModelSuggestions(modelDatalist, []);
+      const modelSetting = modelControl.setting;
+      const { setting, dropdown } = reasoningControl;
+      if (modelSetting) this.showModelCatalogStatus(modelSetting, undefined);
+      if (setting && dropdown) {
+        this.showReasoningSupport(setting, dropdown, undefined);
+      }
       if (this.reasoningSupportRefreshTimer) {
         clearTimeout(this.reasoningSupportRefreshTimer);
       }
       this.reasoningSupportRefreshTimer = setTimeout(
-        () => void refreshReasoningSupport(),
+        () => void refreshProviderModels(),
         500,
       );
     };
@@ -98,7 +139,7 @@ export class SettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings?.apiKey || "")
           .onChange(async (value) => {
             this.plugin.settings.apiKey = value;
-            scheduleReasoningSupportRefresh();
+            scheduleProviderModelsRefresh();
             await this.plugin.saveSettings();
           });
         text.inputEl.type = "password";
@@ -115,27 +156,36 @@ export class SettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings?.providerUrl || "")
           .onChange(async (value) => {
             this.plugin.settings.providerUrl = value;
-            scheduleReasoningSupportRefresh();
+            scheduleProviderModelsRefresh();
             await this.plugin.saveSettings();
           })
           .setPlaceholder("https://api.openai.com/v1"),
       );
 
-    new Setting(containerEl)
+    modelControl.setting = new Setting(containerEl)
       .setName("🤖 Model name")
       .setDesc(
         "The specific AI model to use (e.g., gpt-4, claude-3-sonnet, gemini-pro). Check your provider's model list.",
       )
-      .addText((text) =>
+      .addText((text) => {
         text
           .setValue(this.plugin.settings?.model || "")
           .onChange(async (value) => {
             this.plugin.settings.model = value;
-            scheduleReasoningSupportRefresh();
+            if (providerModelsResult) {
+              await applyProviderModels(providerModelsResult, false);
+            }
             await this.plugin.saveSettings();
           })
-          .setPlaceholder("gpt-4 or your preferred model"),
-      );
+          .setPlaceholder("gpt-4 or your preferred model");
+        text.inputEl.setAttribute("list", modelDatalist.id);
+        text.inputEl.setAttribute("autocomplete", "off");
+        text.inputEl.addEventListener("change", () => {
+          if (providerModelsResult) {
+            void applyProviderModels(providerModelsResult, true);
+          }
+        });
+      });
 
     reasoningControl.setting = new Setting(containerEl)
       .setName("🧠 Reasoning effort")
@@ -157,11 +207,11 @@ export class SettingTab extends PluginSettingTab {
       .addExtraButton((button) =>
         button
           .setIcon("refresh-cw")
-          .setTooltip("Check model reasoning support")
-          .onClick(refreshReasoningSupport),
+          .setTooltip("Refresh provider models")
+          .onClick(refreshProviderModels),
       );
 
-    void refreshReasoningSupport();
+    void refreshProviderModels();
 
     new Setting(containerEl)
       .setName("📁 Project ID (optional)")
@@ -248,6 +298,55 @@ export class SettingTab extends PluginSettingTab {
       clearTimeout(this.reasoningSupportRefreshTimer);
       this.reasoningSupportRefreshTimer = undefined;
     }
+  }
+
+  private showModelCatalogStatus(
+    setting: Setting,
+    result: ProviderModelsResult | undefined,
+    model = "",
+  ): void {
+    setting.descEl.style.color = "";
+    if (!result) {
+      setting.setDesc("Loading models from provider...");
+      return;
+    }
+
+    if (result.status === "success") {
+      if (!model) {
+        setting.setDesc("Select a provider model or enter a custom model name.");
+      } else if (result.models.some(({ id }) => id === model)) {
+        setting.setDesc("Model found in provider catalog.");
+        setting.descEl.style.color = "var(--text-success)";
+      } else {
+        setting.setDesc(
+          "Model is not listed by the provider. Custom model names are still allowed.",
+        );
+        setting.descEl.style.color = "var(--text-warning)";
+      }
+      return;
+    }
+
+    const description =
+      result.reason === "invalid-config"
+        ? "Enter a valid Base URL to load model suggestions. Custom model names are allowed."
+        : result.reason === "lookup-failed"
+          ? "Could not load provider models. Custom model names are still allowed."
+          : "This provider does not return a model catalog. Custom model names are allowed.";
+    setting.setDesc(description);
+    setting.descEl.style.color = "var(--text-muted)";
+  }
+
+  private setModelSuggestions(
+    datalist: HTMLDataListElement,
+    modelIds: readonly string[],
+  ): void {
+    const fragment = document.createDocumentFragment();
+    for (const modelId of [...modelIds].sort()) {
+      const option = document.createElement("option");
+      option.value = modelId;
+      fragment.append(option);
+    }
+    datalist.replaceChildren(fragment);
   }
 
   private showReasoningSupport(

--- a/src/setting-tab.ts
+++ b/src/setting-tab.ts
@@ -1,9 +1,11 @@
 import {
   App,
   DropdownComponent,
+  Notice,
   PluginSettingTab,
   Setting,
 } from "obsidian";
+import { mapLlmErrorToReadable } from "./llm/error-handler";
 import {
   getProviderModels,
   parseModelReasoningSupportFromModels,
@@ -16,12 +18,16 @@ import {
 } from "./llm/reasoning-effort";
 import LlmShortcutPlugin from "./main";
 import { PROMPT_OPTION_DEFINITIONS } from "./prompt/prompt-option-registry";
+import { createProviderPreset } from "./settings";
+import { showErrorNotification } from "./ui/user-notifications";
+import { AbortError } from "./utils/abort-error";
 import { obsidianFetchAdapter } from "./utils/obsidian/obsidian-fetch-adapter";
 
 export class SettingTab extends PluginSettingTab {
   private plugin: LlmShortcutPlugin;
   private reasoningSupportRefreshTimer: ReturnType<typeof setTimeout> | undefined;
   private reasoningSupportLookupId = 0;
+  private presetTestAbortController: AbortController | undefined;
 
   constructor(app: App, plugin: LlmShortcutPlugin) {
     super(app, plugin);
@@ -30,6 +36,8 @@ export class SettingTab extends PluginSettingTab {
 
   override display(): void {
     const { containerEl } = this;
+    this.presetTestAbortController?.abort();
+    this.presetTestAbortController = undefined;
     containerEl.empty();
     this.cancelReasoningSupportRefresh();
 
@@ -50,14 +58,14 @@ export class SettingTab extends PluginSettingTab {
       const modelSetting = modelControl.setting;
       if (!modelSetting || !setting || !dropdown) return;
 
-      this.showModelCatalogStatus(modelSetting, result, this.plugin.settings.model);
+      this.showModelCatalogStatus(modelSetting, result, this.plugin.currentPreset.model);
       const support: ModelReasoningSupport =
-        !this.plugin.settings.model
+        !this.plugin.currentPreset.model
           ? { status: "unknown", reason: "invalid-config" }
           : result.status === "success"
           ? parseModelReasoningSupportFromModels(
               result.models,
-              this.plugin.settings.model,
+              this.plugin.currentPreset.model,
             )
           : result;
       const shouldClearEffort = this.showReasoningSupport(
@@ -66,7 +74,7 @@ export class SettingTab extends PluginSettingTab {
         support,
       );
       if (shouldClearEffort && clearUnsupportedEffort) {
-        this.plugin.settings.reasoningEffort = undefined;
+        this.plugin.currentPreset.reasoningEffort = undefined;
         dropdown.setValue("");
         await this.plugin.saveSettings();
       }
@@ -79,8 +87,8 @@ export class SettingTab extends PluginSettingTab {
 
       const currentLookupId = ++this.reasoningSupportLookupId;
       const lookupConfig = {
-        apiKey: this.plugin.settings.apiKey,
-        baseUrl: this.plugin.settings.providerUrl,
+        apiKey: this.plugin.currentPreset.apiKey,
+        baseUrl: this.plugin.currentPreset.providerUrl,
       };
       this.showModelCatalogStatus(modelSetting, undefined);
       this.showReasoningSupport(
@@ -94,8 +102,8 @@ export class SettingTab extends PluginSettingTab {
       });
       if (
         currentLookupId !== this.reasoningSupportLookupId ||
-        lookupConfig.apiKey !== this.plugin.settings.apiKey ||
-        lookupConfig.baseUrl !== this.plugin.settings.providerUrl
+        lookupConfig.apiKey !== this.plugin.currentPreset.apiKey ||
+        lookupConfig.baseUrl !== this.plugin.currentPreset.providerUrl
       ) {
         return;
       }
@@ -127,7 +135,83 @@ export class SettingTab extends PluginSettingTab {
       );
     };
 
-    new Setting(containerEl).setName("LLM provider").setHeading();
+    new Setting(containerEl).setName("LLM presets").setHeading();
+
+    let presetDropdown: DropdownComponent | undefined;
+    new Setting(containerEl)
+      .setName("Current preset")
+      .setDesc("Select the provider and model configuration used by commands.")
+      .addDropdown((dropdown) => {
+        presetDropdown = dropdown;
+        for (const preset of this.plugin.settings.presets) {
+          dropdown.addOption(preset.id, preset.name);
+        }
+        dropdown
+          .setValue(this.plugin.settings.currentPresetId)
+          .onChange(async (value) => {
+            this.plugin.settings.currentPresetId = value;
+            this.display();
+            await this.plugin.saveSettings();
+          });
+      })
+      .addExtraButton((button) =>
+        button
+          .setIcon("plus")
+          .setTooltip("Add preset")
+          .onClick(async () => {
+            let presetNumber = 1;
+            while (
+              this.plugin.settings.presets.some(
+                ({ name }) => name === `Preset ${presetNumber}`,
+              )
+            ) {
+              presetNumber += 1;
+            }
+            const preset = createProviderPreset(`Preset ${presetNumber}`);
+            this.plugin.settings.presets.push(preset);
+            this.plugin.settings.currentPresetId = preset.id;
+            this.display();
+            await this.plugin.saveSettings();
+          }),
+      )
+      .addExtraButton((button) =>
+        button
+          .setIcon("trash-2")
+          .setTooltip("Delete current preset")
+          .setDisabled(this.plugin.settings.presets.length === 1)
+          .onClick(async () => {
+            const presetName = this.plugin.currentPreset.name;
+            if (!window.confirm(`Delete preset "${presetName}"?`)) return;
+
+            const currentPresetId = this.plugin.settings.currentPresetId;
+            this.plugin.settings.presets = this.plugin.settings.presets.filter(
+              ({ id }) => id !== currentPresetId,
+            );
+            this.plugin.settings.currentPresetId =
+              this.plugin.settings.presets[0]!.id;
+            this.display();
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Preset name")
+      .setDesc("A label used only in this plugin's settings.")
+      .addText((text) =>
+        text
+          .setValue(this.plugin.currentPreset.name)
+          .onChange(async (value) => {
+            this.plugin.currentPreset.name = value || "Untitled preset";
+            const option = Array.from(
+              presetDropdown?.selectEl.options ?? [],
+            ).find(({ value }) => value === this.plugin.currentPreset.id);
+            if (option) option.text = this.plugin.currentPreset.name;
+            await this.plugin.saveSettings();
+          })
+          .setPlaceholder("Preset name"),
+      );
+
+    new Setting(containerEl).setName("Provider configuration").setHeading();
 
     new Setting(containerEl)
       .setName("🔑 API key")
@@ -136,9 +220,9 @@ export class SettingTab extends PluginSettingTab {
       )
       .addText((text) => {
         text
-          .setValue(this.plugin.settings?.apiKey || "")
+          .setValue(this.plugin.currentPreset.apiKey)
           .onChange(async (value) => {
-            this.plugin.settings.apiKey = value;
+            this.plugin.currentPreset.apiKey = value;
             scheduleProviderModelsRefresh();
             await this.plugin.saveSettings();
           });
@@ -153,9 +237,9 @@ export class SettingTab extends PluginSettingTab {
       )
       .addText((text) =>
         text
-          .setValue(this.plugin.settings?.providerUrl || "")
+          .setValue(this.plugin.currentPreset.providerUrl)
           .onChange(async (value) => {
-            this.plugin.settings.providerUrl = value;
+            this.plugin.currentPreset.providerUrl = value;
             scheduleProviderModelsRefresh();
             await this.plugin.saveSettings();
           })
@@ -169,9 +253,9 @@ export class SettingTab extends PluginSettingTab {
       )
       .addText((text) => {
         text
-          .setValue(this.plugin.settings?.model || "")
+          .setValue(this.plugin.currentPreset.model)
           .onChange(async (value) => {
-            this.plugin.settings.model = value;
+            this.plugin.currentPreset.model = value;
             if (providerModelsResult) {
               await applyProviderModels(providerModelsResult, false);
             }
@@ -197,9 +281,9 @@ export class SettingTab extends PluginSettingTab {
         this.setReasoningOptions(dropdown, REASONING_EFFORTS);
 
         dropdown
-          .setValue(this.plugin.settings.reasoningEffort ?? "")
+          .setValue(this.plugin.currentPreset.reasoningEffort ?? "")
           .onChange(async (value) => {
-            this.plugin.settings.reasoningEffort =
+            this.plugin.currentPreset.reasoningEffort =
               isReasoningEffort(value) ? value : undefined;
             await this.plugin.saveSettings();
           });
@@ -220,12 +304,38 @@ export class SettingTab extends PluginSettingTab {
       )
       .addText((text) =>
         text
-          .setValue(this.plugin.settings?.project || "")
+          .setValue(this.plugin.currentPreset.project)
           .onChange(async (value) => {
-            this.plugin.settings.project = value;
+            this.plugin.currentPreset.project = value;
             await this.plugin.saveSettings();
           })
           .setPlaceholder("project-id or leave empty"),
+      );
+
+    new Setting(containerEl)
+      .setName("Test current preset")
+      .setDesc("Send a minimal request to verify that the model responds.")
+      .addButton((button) =>
+        button.setButtonText("Test").onClick(async () => {
+          this.presetTestAbortController?.abort();
+          const abortController = new AbortController();
+          this.presetTestAbortController = abortController;
+          const presetName = this.plugin.currentPreset.name;
+          button.setDisabled(true).setButtonText("Testing...");
+          try {
+            await this.plugin.testCurrentPreset(abortController.signal);
+            new Notice(`Preset "${presetName}" responded successfully.`);
+          } catch (error) {
+            if (!(error instanceof AbortError)) {
+              showErrorNotification(mapLlmErrorToReadable(error));
+            }
+          } finally {
+            if (this.presetTestAbortController === abortController) {
+              this.presetTestAbortController = undefined;
+            }
+            button.setDisabled(false).setButtonText("Test");
+          }
+        }),
       );
 
     new Setting(containerEl).setName("Prompt library").setHeading();
@@ -288,6 +398,8 @@ export class SettingTab extends PluginSettingTab {
   }
 
   override hide(): void {
+    this.presetTestAbortController?.abort();
+    this.presetTestAbortController = undefined;
     this.cancelReasoningSupportRefresh();
     super.hide();
   }
@@ -370,8 +482,8 @@ export class SettingTab extends PluginSettingTab {
       setting.descEl.style.color = "var(--text-success)";
       dropdown.setDisabled(false);
       return (
-        this.plugin.settings.reasoningEffort !== undefined &&
-        !supportedEfforts.has(this.plugin.settings.reasoningEffort)
+        this.plugin.currentPreset.reasoningEffort !== undefined &&
+        !supportedEfforts.has(this.plugin.currentPreset.reasoningEffort)
       );
     }
 
@@ -382,7 +494,7 @@ export class SettingTab extends PluginSettingTab {
       );
       setting.descEl.style.color = "var(--text-warning)";
       dropdown.setDisabled(true);
-      return this.plugin.settings.reasoningEffort !== undefined;
+      return this.plugin.currentPreset.reasoningEffort !== undefined;
     }
 
     const description =
@@ -402,7 +514,7 @@ export class SettingTab extends PluginSettingTab {
     dropdown: DropdownComponent,
     efforts: readonly string[],
   ): void {
-    const selectedValue = this.plugin.settings.reasoningEffort ?? "";
+    const selectedValue = this.plugin.currentPreset.reasoningEffort ?? "";
     dropdown.selectEl.empty();
     dropdown.addOption("", "Provider default");
     for (const effort of efforts) {

--- a/src/setting-tab.ts
+++ b/src/setting-tab.ts
@@ -19,6 +19,7 @@ import {
 import LlmShortcutPlugin from "./main";
 import { PROMPT_OPTION_DEFINITIONS } from "./prompt/prompt-option-registry";
 import { createProviderPreset } from "./settings";
+import styles from "./setting-tab.module.css";
 import { showErrorNotification } from "./ui/user-notifications";
 import { AbortError } from "./utils/abort-error";
 import { obsidianFetchAdapter } from "./utils/obsidian/obsidian-fetch-adapter";
@@ -417,7 +418,7 @@ export class SettingTab extends PluginSettingTab {
     result: ProviderModelsResult | undefined,
     model = "",
   ): void {
-    setting.descEl.style.color = "";
+    this.clearStatusClasses(setting);
     if (!result) {
       setting.setDesc("Loading models from provider...");
       return;
@@ -428,12 +429,12 @@ export class SettingTab extends PluginSettingTab {
         setting.setDesc("Select a provider model or enter a custom model name.");
       } else if (result.models.some(({ id }) => id === model)) {
         setting.setDesc("Model found in provider catalog.");
-        setting.descEl.style.color = "var(--text-success)";
+        setting.descEl.addClass(styles.statusSuccess!);
       } else {
         setting.setDesc(
           "Model is not listed by the provider. Custom model names are still allowed.",
         );
-        setting.descEl.style.color = "var(--text-warning)";
+        setting.descEl.addClass(styles.statusWarning!);
       }
       return;
     }
@@ -445,7 +446,7 @@ export class SettingTab extends PluginSettingTab {
           ? "Could not load provider models. Custom model names are still allowed."
           : "This provider does not return a model catalog. Custom model names are allowed.";
     setting.setDesc(description);
-    setting.descEl.style.color = "var(--text-muted)";
+    setting.descEl.addClass(styles.statusMuted!);
   }
 
   private setModelSuggestions(
@@ -466,7 +467,7 @@ export class SettingTab extends PluginSettingTab {
     dropdown: DropdownComponent,
     support: ModelReasoningSupport | undefined,
   ): boolean {
-    setting.descEl.style.color = "";
+    this.clearStatusClasses(setting);
 
     if (!support) {
       this.setReasoningOptions(dropdown, REASONING_EFFORTS);
@@ -479,7 +480,7 @@ export class SettingTab extends PluginSettingTab {
       const supportedEfforts = new Set<string>(support.efforts);
       this.setReasoningOptions(dropdown, support.efforts);
       setting.setDesc("This model supports reasoning effort.");
-      setting.descEl.style.color = "var(--text-success)";
+      setting.descEl.addClass(styles.statusSuccess!);
       dropdown.setDisabled(false);
       return (
         this.plugin.currentPreset.reasoningEffort !== undefined &&
@@ -492,7 +493,7 @@ export class SettingTab extends PluginSettingTab {
       setting.setDesc(
         "This model does not advertise reasoning effort support. Provider default will be used.",
       );
-      setting.descEl.style.color = "var(--text-warning)";
+      setting.descEl.addClass(styles.statusWarning!);
       dropdown.setDisabled(true);
       return this.plugin.currentPreset.reasoningEffort !== undefined;
     }
@@ -505,7 +506,7 @@ export class SettingTab extends PluginSettingTab {
           : "This provider does not advertise reasoning capabilities. Check its model documentation before selecting an effort.";
     this.setReasoningOptions(dropdown, REASONING_EFFORTS);
     setting.setDesc(description);
-    setting.descEl.style.color = "var(--text-muted)";
+    setting.descEl.addClass(styles.statusMuted!);
     dropdown.setDisabled(false);
     return false;
   }
@@ -521,6 +522,14 @@ export class SettingTab extends PluginSettingTab {
       dropdown.addOption(effort, capitalize(effort));
     }
     dropdown.setValue(selectedValue);
+  }
+
+  private clearStatusClasses(setting: Setting): void {
+    setting.descEl.removeClass(
+      styles.statusSuccess!,
+      styles.statusWarning!,
+      styles.statusMuted!,
+    );
   }
 }
 

--- a/src/setting-tab.ts
+++ b/src/setting-tab.ts
@@ -144,13 +144,7 @@ export class SettingTab extends PluginSettingTab {
       )
       .addDropdown((dropdown) => {
         reasoningControl.dropdown = dropdown;
-        dropdown.addOption("", "Provider default");
-        for (const effort of REASONING_EFFORTS) {
-          dropdown.addOption(
-            effort,
-            effort.charAt(0).toUpperCase() + effort.slice(1),
-          );
-        }
+        this.setReasoningOptions(dropdown, REASONING_EFFORTS);
 
         dropdown
           .setValue(this.plugin.settings.reasoningEffort ?? "")
@@ -262,11 +256,9 @@ export class SettingTab extends PluginSettingTab {
     support: ModelReasoningSupport | undefined,
   ): boolean {
     setting.descEl.style.color = "";
-    for (const option of Array.from(dropdown.selectEl.options)) {
-      option.disabled = false;
-    }
 
     if (!support) {
+      this.setReasoningOptions(dropdown, REASONING_EFFORTS);
       setting.setDesc("Checking model reasoning support...");
       dropdown.setDisabled(false);
       return false;
@@ -274,12 +266,8 @@ export class SettingTab extends PluginSettingTab {
 
     if (support.status === "supported") {
       const supportedEfforts = new Set<string>(support.efforts);
-      for (const option of Array.from(dropdown.selectEl.options)) {
-        option.disabled = option.value !== "" && !supportedEfforts.has(option.value);
-      }
-      setting.setDesc(
-        `Supported efforts: ${support.efforts.map(capitalize).join(", ")}.`,
-      );
+      this.setReasoningOptions(dropdown, support.efforts);
+      setting.setDesc("This model supports reasoning effort.");
       setting.descEl.style.color = "var(--text-success)";
       dropdown.setDisabled(false);
       return (
@@ -289,6 +277,7 @@ export class SettingTab extends PluginSettingTab {
     }
 
     if (support.status === "unsupported") {
+      this.setReasoningOptions(dropdown, []);
       setting.setDesc(
         "This model does not advertise reasoning effort support. Provider default will be used.",
       );
@@ -303,14 +292,27 @@ export class SettingTab extends PluginSettingTab {
         : support.reason === "lookup-failed"
           ? "Could not check reasoning support. Verify the provider URL and API key, then retry."
           : "This provider does not advertise reasoning capabilities. Check its model documentation before selecting an effort.";
+    this.setReasoningOptions(dropdown, REASONING_EFFORTS);
     setting.setDesc(description);
     setting.descEl.style.color = "var(--text-muted)";
     dropdown.setDisabled(false);
     return false;
   }
+
+  private setReasoningOptions(
+    dropdown: DropdownComponent,
+    efforts: readonly string[],
+  ): void {
+    const selectedValue = this.plugin.settings.reasoningEffort ?? "";
+    dropdown.selectEl.empty();
+    dropdown.addOption("", "Provider default");
+    for (const effort of efforts) {
+      dropdown.addOption(effort, capitalize(effort));
+    }
+    dropdown.setValue(selectedValue);
+  }
 }
 
 function capitalize(value: string): string {
-  if (value === "xhigh") return "XHigh";
   return value.charAt(0).toUpperCase() + value.slice(1);
 }

--- a/src/setting-tab.ts
+++ b/src/setting-tab.ts
@@ -1,4 +1,8 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
+import {
+  isReasoningEffort,
+  REASONING_EFFORTS,
+} from "./llm/reasoning-effort";
 import LlmShortcutPlugin from "./main";
 import { PROMPT_OPTION_DEFINITIONS } from "./prompt/prompt-option-registry";
 
@@ -61,6 +65,29 @@ export class SettingTab extends PluginSettingTab {
           })
           .setPlaceholder("gpt-4 or your preferred model"),
       );
+
+    new Setting(containerEl)
+      .setName("🧠 Reasoning effort")
+      .setDesc(
+        "The thinking level for reasoning models. Use provider default for models or providers that do not support this option.",
+      )
+      .addDropdown((dropdown) => {
+        dropdown.addOption("", "Provider default");
+        for (const effort of REASONING_EFFORTS) {
+          dropdown.addOption(
+            effort,
+            effort.charAt(0).toUpperCase() + effort.slice(1),
+          );
+        }
+
+        dropdown
+          .setValue(this.plugin.settings.reasoningEffort ?? "")
+          .onChange(async (value) => {
+            this.plugin.settings.reasoningEffort =
+              isReasoningEffort(value) ? value : undefined;
+            await this.plugin.saveSettings();
+          });
+      });
 
     new Setting(containerEl)
       .setName("📁 Project ID (optional)")

--- a/src/setting-tab.ts
+++ b/src/setting-tab.ts
@@ -1,13 +1,25 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import {
+  App,
+  DropdownComponent,
+  PluginSettingTab,
+  Setting,
+} from "obsidian";
+import {
+  getModelReasoningSupport,
+  type ModelReasoningSupport,
+} from "./llm/get-model-reasoning-support";
 import {
   isReasoningEffort,
   REASONING_EFFORTS,
 } from "./llm/reasoning-effort";
 import LlmShortcutPlugin from "./main";
 import { PROMPT_OPTION_DEFINITIONS } from "./prompt/prompt-option-registry";
+import { obsidianFetchAdapter } from "./utils/obsidian/obsidian-fetch-adapter";
 
 export class SettingTab extends PluginSettingTab {
   private plugin: LlmShortcutPlugin;
+  private reasoningSupportRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+  private reasoningSupportLookupId = 0;
 
   constructor(app: App, plugin: LlmShortcutPlugin) {
     super(app, plugin);
@@ -17,6 +29,62 @@ export class SettingTab extends PluginSettingTab {
   override display(): void {
     const { containerEl } = this;
     containerEl.empty();
+    this.cancelReasoningSupportRefresh();
+
+    const reasoningControl: {
+      setting?: Setting;
+      dropdown?: DropdownComponent;
+    } = {};
+    const refreshReasoningSupport = async () => {
+      const { setting, dropdown } = reasoningControl;
+      if (!setting || !dropdown) return;
+
+      const currentLookupId = ++this.reasoningSupportLookupId;
+      const lookupConfig = {
+        apiKey: this.plugin.settings.apiKey,
+        baseUrl: this.plugin.settings.providerUrl,
+        model: this.plugin.settings.model,
+      };
+      this.showReasoningSupport(
+        setting,
+        dropdown,
+        undefined,
+      );
+      const support = await getModelReasoningSupport({
+        ...lookupConfig,
+        fetch: obsidianFetchAdapter,
+      });
+      if (
+        currentLookupId !== this.reasoningSupportLookupId ||
+        lookupConfig.apiKey !== this.plugin.settings.apiKey ||
+        lookupConfig.baseUrl !== this.plugin.settings.providerUrl ||
+        lookupConfig.model !== this.plugin.settings.model
+      ) {
+        return;
+      }
+
+      const shouldClearEffort = this.showReasoningSupport(
+        setting,
+        dropdown,
+        support,
+      );
+      if (shouldClearEffort) {
+        this.plugin.settings.reasoningEffort = undefined;
+        dropdown.setValue("");
+        await this.plugin.saveSettings();
+      }
+    };
+
+    const scheduleReasoningSupportRefresh = () => {
+      this.reasoningSupportLookupId += 1;
+      if (this.reasoningSupportRefreshTimer) {
+        clearTimeout(this.reasoningSupportRefreshTimer);
+      }
+      this.reasoningSupportRefreshTimer = setTimeout(
+        () => void refreshReasoningSupport(),
+        500,
+      );
+    };
 
     new Setting(containerEl).setName("LLM provider").setHeading();
 
@@ -30,6 +98,7 @@ export class SettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings?.apiKey || "")
           .onChange(async (value) => {
             this.plugin.settings.apiKey = value;
+            scheduleReasoningSupportRefresh();
             await this.plugin.saveSettings();
           });
         text.inputEl.type = "password";
@@ -46,6 +115,7 @@ export class SettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings?.providerUrl || "")
           .onChange(async (value) => {
             this.plugin.settings.providerUrl = value;
+            scheduleReasoningSupportRefresh();
             await this.plugin.saveSettings();
           })
           .setPlaceholder("https://api.openai.com/v1"),
@@ -61,17 +131,19 @@ export class SettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings?.model || "")
           .onChange(async (value) => {
             this.plugin.settings.model = value;
+            scheduleReasoningSupportRefresh();
             await this.plugin.saveSettings();
           })
           .setPlaceholder("gpt-4 or your preferred model"),
       );
 
-    new Setting(containerEl)
+    reasoningControl.setting = new Setting(containerEl)
       .setName("🧠 Reasoning effort")
       .setDesc(
         "The thinking level for reasoning models. Use provider default for models or providers that do not support this option.",
       )
       .addDropdown((dropdown) => {
+        reasoningControl.dropdown = dropdown;
         dropdown.addOption("", "Provider default");
         for (const effort of REASONING_EFFORTS) {
           dropdown.addOption(
@@ -87,7 +159,15 @@ export class SettingTab extends PluginSettingTab {
               isReasoningEffort(value) ? value : undefined;
             await this.plugin.saveSettings();
           });
-      });
+      })
+      .addExtraButton((button) =>
+        button
+          .setIcon("refresh-cw")
+          .setTooltip("Check model reasoning support")
+          .onClick(refreshReasoningSupport),
+      );
+
+    void refreshReasoningSupport();
 
     new Setting(containerEl)
       .setName("📁 Project ID (optional)")
@@ -162,4 +242,75 @@ export class SettingTab extends PluginSettingTab {
       );
     }
   }
+
+  override hide(): void {
+    this.cancelReasoningSupportRefresh();
+    super.hide();
+  }
+
+  private cancelReasoningSupportRefresh(): void {
+    this.reasoningSupportLookupId += 1;
+    if (this.reasoningSupportRefreshTimer) {
+      clearTimeout(this.reasoningSupportRefreshTimer);
+      this.reasoningSupportRefreshTimer = undefined;
+    }
+  }
+
+  private showReasoningSupport(
+    setting: Setting,
+    dropdown: DropdownComponent,
+    support: ModelReasoningSupport | undefined,
+  ): boolean {
+    setting.descEl.style.color = "";
+    for (const option of Array.from(dropdown.selectEl.options)) {
+      option.disabled = false;
+    }
+
+    if (!support) {
+      setting.setDesc("Checking model reasoning support...");
+      dropdown.setDisabled(false);
+      return false;
+    }
+
+    if (support.status === "supported") {
+      const supportedEfforts = new Set<string>(support.efforts);
+      for (const option of Array.from(dropdown.selectEl.options)) {
+        option.disabled = option.value !== "" && !supportedEfforts.has(option.value);
+      }
+      setting.setDesc(
+        `Supported efforts: ${support.efforts.map(capitalize).join(", ")}.`,
+      );
+      setting.descEl.style.color = "var(--text-success)";
+      dropdown.setDisabled(false);
+      return (
+        this.plugin.settings.reasoningEffort !== undefined &&
+        !supportedEfforts.has(this.plugin.settings.reasoningEffort)
+      );
+    }
+
+    if (support.status === "unsupported") {
+      setting.setDesc(
+        "This model does not advertise reasoning effort support. Provider default will be used.",
+      );
+      setting.descEl.style.color = "var(--text-warning)";
+      dropdown.setDisabled(true);
+      return this.plugin.settings.reasoningEffort !== undefined;
+    }
+
+    const description =
+      support.reason === "invalid-config"
+        ? "Enter a valid Base URL and model name to check reasoning support."
+        : support.reason === "lookup-failed"
+          ? "Could not check reasoning support. Verify the provider URL and API key, then retry."
+          : "This provider does not advertise reasoning capabilities. Check its model documentation before selecting an effort.";
+    setting.setDesc(description);
+    setting.descEl.style.color = "var(--text-muted)";
+    dropdown.setDisabled(false);
+    return false;
+  }
+}
+
+function capitalize(value: string): string {
+  if (value === "xhigh") return "XHigh";
+  return value.charAt(0).toUpperCase() + value.slice(1);
 }

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { getCurrentPreset, migratePluginSettings } from "./settings";
+import {
+  createDefaultSettings,
+  getCurrentPreset,
+  migratePluginSettings,
+} from "./settings";
+
+describe("createDefaultSettings", () => {
+  it("creates independent global prompt options", () => {
+    expect(createDefaultSettings().globalPromptOptions).not.toBe(
+      createDefaultSettings().globalPromptOptions,
+    );
+  });
+});
 
 describe("migratePluginSettings", () => {
   it("migrates legacy provider fields into the default preset", () => {
@@ -85,5 +97,41 @@ describe("migratePluginSettings", () => {
       "preset-3",
     ]);
     expect(getCurrentPreset(settings).name).toBe("First");
+  });
+
+  it("ignores invalid persisted global prompt options", () => {
+    const settings = migratePluginSettings({
+      globalPromptOptions: {
+        shouldHandleSelectionOnly: "false",
+        contextSizeBefore: -1,
+        contextSizeAfter: 1.5,
+        promptResponseProcessingMode: "invalid",
+      },
+    });
+
+    expect(settings.globalPromptOptions).toEqual({
+      shouldHandleSelectionOnly: undefined,
+      contextSizeBefore: undefined,
+      contextSizeAfter: undefined,
+      promptResponseProcessingMode: undefined,
+    });
+  });
+
+  it("preserves valid persisted global prompt options", () => {
+    const settings = migratePluginSettings({
+      globalPromptOptions: {
+        shouldHandleSelectionOnly: true,
+        contextSizeBefore: 0,
+        contextSizeAfter: 100,
+        promptResponseProcessingMode: "info",
+      },
+    });
+
+    expect(settings.globalPromptOptions).toEqual({
+      shouldHandleSelectionOnly: true,
+      contextSizeBefore: 0,
+      contextSizeAfter: 100,
+      promptResponseProcessingMode: "info",
+    });
   });
 });

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { getCurrentPreset, migratePluginSettings } from "./settings";
+
+describe("migratePluginSettings", () => {
+  it("migrates legacy provider fields into the default preset", () => {
+    const settings = migratePluginSettings({
+      apiKey: "legacy-key",
+      providerUrl: "https://provider.example/v1",
+      model: "provider/model",
+      reasoningEffort: "xhigh",
+      project: "legacy-project",
+      promptLibraryDirectory: "prompts",
+      customPromptCommandLabel: "Ask model",
+      globalPromptOptions: { contextSizeBefore: 100 },
+    });
+
+    expect(settings.currentPresetId).toBe("default");
+    expect(getCurrentPreset(settings)).toEqual({
+      id: "default",
+      name: "Default",
+      apiKey: "legacy-key",
+      providerUrl: "https://provider.example/v1",
+      model: "provider/model",
+      reasoningEffort: "xhigh",
+      project: "legacy-project",
+    });
+    expect(settings.promptLibraryDirectory).toBe("prompts");
+    expect(settings.customPromptCommandLabel).toBe("Ask model");
+    expect(settings.globalPromptOptions.contextSizeBefore).toBe(100);
+  });
+
+  it("preserves valid presets and the current selection", () => {
+    const settings = migratePluginSettings({
+      presets: [
+        {
+          id: "first",
+          name: "First",
+          apiKey: "key-1",
+          providerUrl: "https://one.example/v1",
+          model: "model-1",
+          reasoningEffort: "low",
+          project: "",
+        },
+        {
+          id: "second",
+          name: "Second",
+          apiKey: "key-2",
+          providerUrl: "https://two.example/v1",
+          model: "model-2",
+          reasoningEffort: "max",
+          project: "project-2",
+        },
+      ],
+      currentPresetId: "second",
+    });
+
+    expect(settings.presets).toHaveLength(2);
+    expect(getCurrentPreset(settings).name).toBe("Second");
+    expect(getCurrentPreset(settings).reasoningEffort).toBe("max");
+  });
+
+  it("falls back to the first preset when the selection is invalid", () => {
+    const settings = migratePluginSettings({
+      presets: [{ id: "available", name: "Available" }],
+      currentPresetId: "missing",
+    });
+
+    expect(settings.currentPresetId).toBe("available");
+    expect(getCurrentPreset(settings).reasoningEffort).toBeUndefined();
+  });
+
+  it("normalizes empty and duplicate preset IDs", () => {
+    const settings = migratePluginSettings({
+      presets: [
+        { id: "duplicate", name: "First" },
+        { id: "duplicate", name: "Second" },
+        { id: "", name: "Third" },
+      ],
+      currentPresetId: "duplicate",
+    });
+
+    expect(settings.presets.map(({ id }) => id)).toEqual([
+      "duplicate",
+      "duplicate-2",
+      "preset-3",
+    ]);
+    expect(getCurrentPreset(settings).name).toBe("First");
+  });
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,145 @@
+import { isReasoningEffort, type ReasoningEffort } from "./llm/reasoning-effort";
+import {
+  DEFAULT_PROMPT_OPTIONS,
+  type PromptOptions,
+} from "./prompt/user-prompt-options";
+
+export interface ProviderPreset {
+  id: string;
+  name: string;
+  apiKey: string;
+  providerUrl: string;
+  model: string;
+  reasoningEffort: ReasoningEffort | undefined;
+  project: string;
+}
+
+export interface PluginSettings {
+  presets: ProviderPreset[];
+  currentPresetId: string;
+  promptLibraryDirectory: string;
+  customPromptCommandLabel: string;
+  globalPromptOptions: PromptOptions;
+}
+
+export function createProviderPreset(
+  name: string,
+  id: string = createPresetId(),
+): ProviderPreset {
+  return {
+    id,
+    name,
+    apiKey: "",
+    providerUrl: "",
+    model: "",
+    reasoningEffort: undefined,
+    project: "",
+  };
+}
+
+export function createDefaultSettings(): PluginSettings {
+  const preset = createProviderPreset("Default", "default");
+  return {
+    presets: [preset],
+    currentPresetId: preset.id,
+    promptLibraryDirectory: "_prompts",
+    customPromptCommandLabel: "Custom prompt",
+    globalPromptOptions: DEFAULT_PROMPT_OPTIONS,
+  };
+}
+
+export function getCurrentPreset(settings: PluginSettings): ProviderPreset {
+  return (
+    settings.presets.find(({ id }) => id === settings.currentPresetId) ??
+    settings.presets[0]!
+  );
+}
+
+export function clonePluginSettings(settings: PluginSettings): PluginSettings {
+  return {
+    ...settings,
+    presets: settings.presets.map((preset) => ({ ...preset })),
+    globalPromptOptions: { ...settings.globalPromptOptions },
+  };
+}
+
+export function migratePluginSettings(data: unknown): PluginSettings {
+  const defaults = createDefaultSettings();
+  if (!isRecord(data)) return defaults;
+
+  const presets = parsePresets(data.presets) ?? [migrateLegacyPreset(data)];
+  const currentPresetId =
+    typeof data.currentPresetId === "string" &&
+    presets.some(({ id }) => id === data.currentPresetId)
+      ? data.currentPresetId
+      : presets[0]!.id;
+
+  return {
+    presets,
+    currentPresetId,
+    promptLibraryDirectory: getString(
+      data.promptLibraryDirectory,
+      defaults.promptLibraryDirectory,
+    ),
+    customPromptCommandLabel: getString(
+      data.customPromptCommandLabel,
+      defaults.customPromptCommandLabel,
+    ),
+    globalPromptOptions: {
+      ...DEFAULT_PROMPT_OPTIONS,
+      ...(isRecord(data.globalPromptOptions) ? data.globalPromptOptions : {}),
+    },
+  };
+}
+
+function parsePresets(value: unknown): ProviderPreset[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+
+  const usedIds = new Set<string>();
+  return value.map((preset, index) => {
+    const data = isRecord(preset) ? preset : {};
+    const requestedId = getString(data.id);
+    let id = requestedId || `preset-${index + 1}`;
+    for (let suffix = 2; usedIds.has(id); suffix += 1) {
+      id = `${requestedId || `preset-${index + 1}`}-${suffix}`;
+    }
+    usedIds.add(id);
+    return {
+      id,
+      name: getString(data.name, `Preset ${index + 1}`),
+      apiKey: getString(data.apiKey),
+      providerUrl: getString(data.providerUrl),
+      model: getString(data.model),
+      reasoningEffort: isReasoningEffort(data.reasoningEffort)
+        ? data.reasoningEffort
+        : undefined,
+      project: getString(data.project),
+    };
+  });
+}
+
+function migrateLegacyPreset(data: Record<string, unknown>): ProviderPreset {
+  return {
+    id: "default",
+    name: "Default",
+    apiKey: getString(data.apiKey),
+    providerUrl: getString(data.providerUrl),
+    model: getString(data.model),
+    reasoningEffort: isReasoningEffort(data.reasoningEffort)
+      ? data.reasoningEffort
+      : undefined,
+    project: getString(data.project),
+  };
+}
+
+function getString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function createPresetId(): string {
+  return `preset-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import { isReasoningEffort, type ReasoningEffort } from "./llm/reasoning-effort";
 import {
+  ALL_PROMPT_RESPONSE_PROCESSING_MODES,
   DEFAULT_PROMPT_OPTIONS,
   type PromptOptions,
 } from "./prompt/user-prompt-options";
@@ -44,7 +45,7 @@ export function createDefaultSettings(): PluginSettings {
     currentPresetId: preset.id,
     promptLibraryDirectory: "_prompts",
     customPromptCommandLabel: "Custom prompt",
-    globalPromptOptions: DEFAULT_PROMPT_OPTIONS,
+    globalPromptOptions: { ...DEFAULT_PROMPT_OPTIONS },
   };
 }
 
@@ -85,10 +86,7 @@ export function migratePluginSettings(data: unknown): PluginSettings {
       data.customPromptCommandLabel,
       defaults.customPromptCommandLabel,
     ),
-    globalPromptOptions: {
-      ...DEFAULT_PROMPT_OPTIONS,
-      ...(isRecord(data.globalPromptOptions) ? data.globalPromptOptions : {}),
-    },
+    globalPromptOptions: parsePromptOptions(data.globalPromptOptions),
   };
 }
 
@@ -130,6 +128,29 @@ function migrateLegacyPreset(data: Record<string, unknown>): ProviderPreset {
       : undefined,
     project: getString(data.project),
   };
+}
+
+function parsePromptOptions(value: unknown): PromptOptions {
+  const data = isRecord(value) ? value : {};
+  return {
+    shouldHandleSelectionOnly:
+      data.shouldHandleSelectionOnly === true ? true : undefined,
+    contextSizeBefore: parseContextSize(data.contextSizeBefore),
+    contextSizeAfter: parseContextSize(data.contextSizeAfter),
+    promptResponseProcessingMode:
+      typeof data.promptResponseProcessingMode === "string" &&
+      ALL_PROMPT_RESPONSE_PROCESSING_MODES.includes(
+        data.promptResponseProcessingMode as (typeof ALL_PROMPT_RESPONSE_PROCESSING_MODES)[number],
+      )
+        ? (data.promptResponseProcessingMode as (typeof ALL_PROMPT_RESPONSE_PROCESSING_MODES)[number])
+        : undefined,
+  };
+}
+
+function parseContextSize(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+    ? value
+    : undefined;
 }
 
 function getString(value: unknown, fallback = ""): string {


### PR DESCRIPTION
## Summary
- add multiple named provider/model presets and select one as current
- migrate existing top-level provider settings into a default preset without data loss
- add a cancelable streaming test action for the current preset
- add model autocomplete from the provider `/models` endpoint while preserving custom model-name input
- add reasoning effort selection and enable only levels advertised for the selected model
- serialize and coalesce settings persistence to protect rapid preset edits

## Testing
- `npm run check:all`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manage multiple provider and model presets, including custom models and per-preset settings.
  * Browse model suggestions with automatic detection of supported reasoning-effort levels.
  * Test the currently selected provider and model connection from settings.
  * Added support for additional reasoning-effort options, including “none,” “xhigh,” and “max.”
* **Bug Fixes**
  * Improved settings migration, validation, preset selection, and handling of concurrent saves.
* **Documentation**
  * Updated setup guidance for provider capabilities, model autocomplete, presets, and response testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->