### PR TITLE
feat: show preset name while loading

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -290,7 +290,9 @@ export default class LlmShortcutPlugin extends Plugin {
     const abortController = new AbortController();
     this.abortController = abortController;
 
-    this.loaderStrategy.start(() => abortController.abort());
+    this.loaderStrategy.start(this.currentPreset.name, () =>
+      abortController.abort(),
+    );
 
     try {
       const responseStream = this.llmClient.getResponse({

--- a/src/ui/loader-strategy.ts
+++ b/src/ui/loader-strategy.ts
@@ -1,16 +1,14 @@
 import { Notice, Platform, Plugin } from "obsidian";
-import { PLUGIN_NAME } from "../utils/constants";
 import {
   createLoadingStatusFragment,
   makeLoadingStatusCancellable,
 } from "./loading-status/loading-status";
+import { getPresetLoadingMessage } from "./loading-status/get-preset-loading-message";
 
 export interface LoaderStrategy {
-  start(onCancel: () => void): void;
+  start(presetName: string, onCancel: () => void): void;
   stop(): void;
 }
-
-const LOADING_MESSAGE = `${PLUGIN_NAME}: Generating...`;
 
 abstract class BaseLoaderStrategy implements LoaderStrategy {
   protected cleanup: (() => void) | undefined;
@@ -19,9 +17,11 @@ abstract class BaseLoaderStrategy implements LoaderStrategy {
     this.cleanup = undefined;
   }
 
-  start(onCancel: () => void): void {
+  start(presetName: string, onCancel: () => void): void {
     this.stop();
-    const fragment = createLoadingStatusFragment(LOADING_MESSAGE);
+    const fragment = createLoadingStatusFragment(
+      getPresetLoadingMessage(presetName),
+    );
     const container = this.mount(fragment);
     if (container) {
       this.cleanup = makeLoadingStatusCancellable(container, onCancel);

--- a/src/ui/loading-status/get-preset-loading-message.spec.ts
+++ b/src/ui/loading-status/get-preset-loading-message.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getPresetLoadingMessage } from "./get-preset-loading-message";
+
+describe("getPresetLoadingMessage", () => {
+  it("uses the preset name", () => {
+    expect(getPresetLoadingMessage("GPT")).toBe("GPT thinking...");
+  });
+
+  it("trims the preset name", () => {
+    expect(getPresetLoadingMessage("  Default  ")).toBe(
+      "Default thinking...",
+    );
+  });
+
+  it("falls back to LLM for an empty name", () => {
+    expect(getPresetLoadingMessage("  ")).toBe("LLM thinking...");
+  });
+});

--- a/src/ui/loading-status/get-preset-loading-message.ts
+++ b/src/ui/loading-status/get-preset-loading-message.ts
@@ -1,0 +1,4 @@
+export function getPresetLoadingMessage(presetName: string): string {
+  const label = presetName.trim() || "LLM";
+  return `${label} thinking...`;
+}


### PR DESCRIPTION
## Summary
- replace the hardcoded LLM loading label with the current preset name
- render loading text as `<preset> thinking...` on desktop and mobile
- trim preset labels and retain an `LLM` fallback for blank names

## Testing
- `npm run check:all`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Loading indicators now show which provider preset is processing a request.
  - Blank or unavailable preset names use a clear fallback message.

- **Bug Fixes**
  - Existing loading status is stopped before a new request status begins, preventing stale messages.

- **Tests**
  - Added coverage for preset-name display, whitespace handling, and fallback messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->